### PR TITLE
Fix : amount must be a valid integer

### DIFF
--- a/app/assets/javascripts/spree/frontend/paystack_checkout.js
+++ b/app/assets/javascripts/spree/frontend/paystack_checkout.js
@@ -14,11 +14,12 @@
   function payWithPaystack(event, orderId, amount, email, currency) {
       event.preventDefault();
       const secret = $("#paystack_checkout_payload").data("secret");
+      const amount_kobo = String(amount) * 100
       let handler = PaystackPop.setup({
         key: secret,
         email: email,
         currency:currency,
-        amount: amount * 100,
+        amount: amount_kobo,
         ref: orderId,
         onClose: function(){
             return false;


### PR DESCRIPTION
 If the price of a product contains cents that are not zero, the plugin fails to load the Paystack Pop up with the error: "amount must be a valid integer" 
![Screen Shot 2022-01-19 at 15 29 15](https://user-images.githubusercontent.com/12971703/150520142-608dd979-638a-4050-89b3-22206f07cb62.png)
.