### PR TITLE
Upgrade Paystack Inline JS

### DIFF
--- a/app/views/spree/checkout/payment/_paystack.html.erb
+++ b/app/views/spree/checkout/payment/_paystack.html.erb
@@ -6,8 +6,8 @@
   data-paymentgateway='<%=SolidusPaystack::PaymentMethod.first.id%>'
   data-current_order_id='<%=current_order.number%>'
   data-billing_email='<%=current_order.email%>'
-  data-secret='<%=SolidusPaystack::PaymentMethod.first.preferred_public_api_key%>'
+  data-secret='<%=SolidusPaystack::PaymentMethod.first.preferred_private_api_key%>'
   data-currency='<%=SolidusPaystack::PaymentMethod.first.preferred_currency%>'
   data-order_total='<%=current_order.total %>'></div>
 
-<script src="https://js.paystack.co/v1/inline.js"></script>
+<script src="https://js.paystack.co/v2/inline.js"></script>


### PR DESCRIPTION
This is an upgrade of InlineJS
 A Javascript library from Paystack that offers a simple, secure, and convenient payment flow for web applications.

Browser support

Paystack Inline is designed to support all recent versions of major browsers. The library is compiled to ES5 and poly-filled to ensure it can work on as many devices as possible.

- We do not support outdated browsers like IE9 nor browsers that disable the use of Javascript, like Opera mini. We require TLS 1.2 to be supported by the browser.
- We support Chrome and Safari on all platforms
- We support Firefox on desktop platforms
- We support the Android native browser on Android 4.4 and later.

Opera Mini support
We don't support Opera Mini because Javascript is disabled in it. We support the Opera browser, however, except in super saver mode where JavaScript is disabled as well.